### PR TITLE
Change basicGet result error_code check from property_exists() to iss…

### DIFF
--- a/src/Buycraft/PocketMine/PluginApi.php
+++ b/src/Buycraft/PocketMine/PluginApi.php
@@ -50,7 +50,7 @@ class PluginApi
             throw new \Exception("Result can't be decoded as JSON.");
         }
 
-        if (property_exists($result, 'error_code')) {
+        if (isset($result['error_code'])) {
             throw new \Exception("Error " . $result->error_code . ": " . $result->error_message);
         }
 


### PR DESCRIPTION
…et() so that if an error_code field intentionally isn't included in the json response / decoded array, then an exception won't be thrown.