### PR TITLE
BUYC-689 Now allowing ALPHA11 API

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,4 +2,4 @@ name: BuycraftPM
 main: Buycraft\PocketMine\BuycraftPlugin
 version: 1.0.0
 author: Tebex Limited
-api: [3.0.0-ALPHA9, 3.0.0-ALPHA10]
+api: [3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]


### PR DESCRIPTION
# Overview
Pocket mine users can now use the plugin with ALPHA11 api.