### PR TITLE
Fix bug in thread sleep

### DIFF
--- a/src/Buycraft/PocketMine/Execution/DuePlayerCheck.php
+++ b/src/Buycraft/PocketMine/Execution/DuePlayerCheck.php
@@ -42,7 +42,7 @@ class DuePlayerCheck extends AsyncTask
         do {
             // Sleep for a while between fetches.
             if ($page > 1) {
-                sleep(mt_rand(5, 15) / 10);
+                usleep(mt_rand(5, 15) * 100000);
             }
 
             try {


### PR DESCRIPTION
PHP's sleep() accepts an integer as it's only parameter. But due to PHP's weak type hinting, it's casting the value of `mt_rand(5 / 15) / 10);` (i.e `[0.5, 1.5]`) to an integer before passing it to sleep() which is why there are no errors.
Instead of sleeping for 0.5-1.5s, what's actually happening is the thread is either never sleeping (`sleep(0)`) or is sleeping for 1 second, as the only possible values of `(int) (mt_rand(5, 15) / 10)` are 0 and 1.
This PR fixes the bug by switching to usleep() instead, which is same as sleep but sleeps the thread for microseconds.