### PR TITLE
Fixed memory leak in due players cache

### DIFF
--- a/src/Buycraft/PocketMine/BuycraftListener.php
+++ b/src/Buycraft/PocketMine/BuycraftListener.php
@@ -30,15 +30,13 @@ class BuycraftListener implements Listener
 
     public function onPlayerJoin(PlayerJoinEvent $event)
     {
-        BuycraftPlugin::getInstance()->getLogger()->info("Executing login commands for " . $event->getPlayer()->getName() . "[XUID: {$event->getPlayer()->getXuid()}]...");
+        $player = $event->getPlayer();
+        if ($this->plugin->isDue($player)) {
+            $duePlayer = $this->plugin->getDue($player);
+            $this->plugin->removeDue($player);
 
-        $lowerName = strtolower($event->getPlayer()->getName());
-        if (array_key_exists($lowerName, BuycraftPlugin::getInstance()->getAllDue())) {
-            $duePlayer = BuycraftPlugin::getInstance()->getAllDue()[$lowerName];
-            unset(BuycraftPlugin::getInstance()->getAllDue()[$lowerName]);
-
-            BuycraftPlugin::getInstance()->getLogger()->info("Executing login commands for " . $event->getPlayer()->getName() . "[XUID: {$event->getPlayer()->getXuid()}]...");
-            Server::getInstance()->getAsyncPool()->submitTask(new PlayerCommandExecutor(BuycraftPlugin::getInstance()->getPluginApi(),
+            $this->plugin->getLogger()->info("Executing login commands for " . $player->getName() . "[XUID: {$player->getXuid()}]...");
+            Server::getInstance()->getAsyncPool()->submitTask(new PlayerCommandExecutor($this->plugin->getPluginApi(),
                 $duePlayer));
         }
     }

--- a/src/Buycraft/PocketMine/BuycraftPlugin.php
+++ b/src/Buycraft/PocketMine/BuycraftPlugin.php
@@ -12,6 +12,7 @@ use Buycraft\PocketMine\Execution\DuePlayerCheck;
 use Buycraft\PocketMine\Execution\CategoryRefreshTask;
 use Buycraft\PocketMine\Util\InventoryUtils;
 use pocketmine\plugin\PluginBase;
+use pocketmine\Player;
 use pocketmine\Server;
 use pocketmine\utils\Config;
 
@@ -145,11 +146,32 @@ class BuycraftPlugin extends PluginBase
     }
 
     /**
-     * @return array
+     * @return bool
      */
-    public function getAllDue(): array
+    public function isDue(Player $player): bool
     {
-        return $this->allDue;
+        return isset($this->allDue[$player->getLowerCaseName()]);
+    }
+
+    /**
+     * @return object
+     */
+    public function getDue(Player $player)
+    {
+        return $this->allDue[$player->getLowerCaseName()];
+    }
+
+    public function removeDue(Player $player): void
+    {
+        unset($this->allDue[$player->getLowerCaseName()]);
+    }
+
+    /**
+     * @param array $allDue
+     */
+    public function setAllDue(array $allDue)
+    {
+        $this->allDue = $allDue;
     }
 
     public function getPlayer(Server $server, $username, $xuid = '')
@@ -170,15 +192,6 @@ class BuycraftPlugin extends PluginBase
         $player = $server->getPlayerExact($username);
 
         return $player ? $player : false;
-    }
-
-    /**
-     * @param array $allDue
-     */
-    public function setAllDue(array $allDue)
-    {
-        // Because PHP logic.
-        $this->allDue = (array)$allDue;
     }
 
     /**


### PR DESCRIPTION
Objects and arrays behave differently in PHP. The code for unset would work if `BuycraftPlugin::getAllDue()` returned an object (which it doesn't). An array returned from a method in such a way doesn't return a direct reference to the original array, rather it returns a copy. `unset(BuycraftPlugin::getInstance()->getAllDue()[$lowerName]);` is unsetting `$lowerName` key from a copy of the array `BuycraftPlugin::getInstance()->getAllDue()` is returning, so `$lowerName` would still exist in `BuycraftPlugin::$allDue`.
```php
class A{
    public $array = ["key" => "value"];
    public function getArray() : array{
        return $this->array;
    }
}

$a = new A();
unset($a->getArray()["key"]);
// A::$array["key"] still exists becauase $a->getArray()
// returns a copy of A::$array, which is what's happening
// with removing due players that BuycraftListener has
// already processed.
```

Luckily, this only causes a short-time memleak since `BuycraftPlugin::setAllDue()` is called continuously through `DuePlayerCheck` which refreshes the `BuycraftPlugin::$allDue` array.

This PR also cuts down on `BuycraftPlugin::getInstance()` calls inside `BuycraftListener` as it already holds an instance of `BuycraftPlugin` which could directly be used instead.