### PR TITLE
Escape player name with spaces for reliability

### DIFF
--- a/src/Buycraft/PocketMine/Execution/QueuedCommand.php
+++ b/src/Buycraft/PocketMine/Execution/QueuedCommand.php
@@ -78,7 +78,7 @@ class QueuedCommand
 
     public function getFinalCommand()
     {
-        $escaped = strpos($un, ' ') !== false ? '"' . $this->username . '"' : $this->username;
+        $escaped = strpos($this->username, ' ') !== false ? '"' . $this->username . '"' : $this->username;
         $command = str_replace(
             [
                 '{name}',

--- a/src/Buycraft/PocketMine/Execution/QueuedCommand.php
+++ b/src/Buycraft/PocketMine/Execution/QueuedCommand.php
@@ -78,6 +78,7 @@ class QueuedCommand
 
     public function getFinalCommand()
     {
+        $escaped = strpos($un, ' ') !== false ? '"' . $this->username . '"' : $this->username;
         $command = str_replace(
             [
                 '{name}',
@@ -88,9 +89,9 @@ class QueuedCommand
                 '{id}'
             ],
             [
-                $this->username,
-                $this->username,
-                $this->username,
+                $escaped,
+                $escaped,
+                $escaped,
                 $this->xuid,
                 $this->xuid,
                 $this->xuid,


### PR DESCRIPTION
This is an issue on PocketMine servers because Xbox Live allows spaces on usernames. And the space character is the delimiter for command arguments.

I suggest adding another placeholder like `{esc_username}` for this (for aesthetic purposes) but I don't think anyone got time to change up their configurations just for that specific purpose.